### PR TITLE
Added platform output for raspberrypi for clarity

### DIFF
--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -40,6 +40,8 @@ endif()
 # temp until further cleanup is done
 # add Raspberry Pi 2 and 3 specific flags
 if(CORE_PLATFORM_NAME_LC STREQUAL rbpi)
+  set(PLATFORM rbpi)
+  include(${CMAKE_SOURCE_DIR}/cmake/platform/${CORE_SYSTEM_NAME}/${CORE_PLATFORM_NAME_LC}.cmake)
   if(CPU MATCHES "cortex-a7")
     set(NEON_FLAGS "-fPIC -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4 -mvectorize-with-neon-quad")
   elseif(CPU MATCHES "cortex-a53")


### PR DESCRIPTION
Set PLATFORM and included rbpi.cmake if a raspberrypi was selected as CORE_SYSTEM_PLATFORM_NAME

## Motivation and Context
It erases the question mark of "did it take my shot at telling it it was a raspberry?"

## How Has This Been Tested?
It's been tested locally on a raspberry pi3.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
